### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled data used in path expression

### DIFF
--- a/middleware/multer.js
+++ b/middleware/multer.js
@@ -29,10 +29,16 @@ module.exports.resizeImage = (req, res, next) => {
     return next();
   }
 
-  const filePath = req.file.path;
+  const filePath = path.resolve(req.file.path);
   const fileName = req.file.filename;
  
   const newFilePath = path.join('images', `resized_${fileName}`);
+
+  // Ensure the filePath is within the 'images' directory
+  if (!filePath.startsWith(path.resolve('images'))) {
+    console.log('Invalid file path');
+    return next();
+  }
 
   sharp.cache(false)
   sharp(filePath)


### PR DESCRIPTION
Potential fix for [https://github.com/Bernard-VERA/Projet-7/security/code-scanning/12](https://github.com/Bernard-VERA/Projet-7/security/code-scanning/12)

To fix the problem, we need to ensure that the `filePath` is validated and sanitized before it is used in file operations. We can achieve this by resolving the path to remove any ".." segments and then checking that the resolved path is within a designated safe directory. This will prevent path traversal attacks and ensure that only files within the intended directory are accessed or deleted.

1. Use `path.resolve` to normalize the `filePath`.
2. Check that the normalized `filePath` starts with the root directory (e.g., 'images').
3. If the check fails, return an error response or skip the file operation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
