### PR TITLE
Potential fix for code scanning alert no. 11: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "mongoose": "^8.2.3",
     "mongoose-unique-validator": "^5.0.0",
     "multer": "^1.4.5-lts.1",
-    "sharp": "^0.33.3"
+    "sharp": "^0.33.3",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/routes/books.js
+++ b/routes/books.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const auth = require('../middleware/auth');
 const multer = require('../middleware/multer');
+const rateLimit = require('express-rate-limit');
 
 const booksCtrl = require('../controllers/books');
 
@@ -12,6 +13,11 @@ router.get('/:id', booksCtrl.getOneBook);
 router.post('/', auth, multer, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', auth, booksCtrl.createRating);
 router.put('/:id', auth, multer, multer.resizeImage, booksCtrl.modifyBook);
-router.delete('/:id', auth, booksCtrl.deleteBook);
+const deleteBookLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 10 // limit each IP to 10 delete requests per windowMs
+});
+
+router.delete('/:id', auth, deleteBookLimiter, booksCtrl.deleteBook);
 
 module.exports = router;


### PR DESCRIPTION
Potential fix for [https://github.com/Bernard-VERA/Projet-7/security/code-scanning/11](https://github.com/Bernard-VERA/Projet-7/security/code-scanning/11)

To fix the problem, we need to introduce rate limiting to the routes in the `routes/books.js` file. We will use the `express-rate-limit` package to limit the number of requests that can be made to the `deleteBook` route within a specified time window. This will help prevent denial-of-service attacks by limiting the rate at which requests are accepted.

We will:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `routes/books.js` file.
3. Define a rate limiter with appropriate settings.
4. Apply the rate limiter to the `deleteBook` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
