### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/routes/books.js
+++ b/routes/books.js
@@ -7,7 +7,12 @@ const rateLimit = require('express-rate-limit');
 const booksCtrl = require('../controllers/books');
 
 // Définition des routes des requètes, notament celles qui nécessitent une authentification
-router.get('/', booksCtrl.getAllBooks);
+const getAllBooksLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100 // limit each IP to 100 requests per windowMs
+});
+
+router.get('/', getAllBooksLimiter, booksCtrl.getAllBooks);
 router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', auth, multer, multer.resizeImage, booksCtrl.createBook);


### PR DESCRIPTION
Potential fix for [https://github.com/Bernard-VERA/Projet-7/security/code-scanning/2](https://github.com/Bernard-VERA/Projet-7/security/code-scanning/2)

To fix the problem, we need to add rate limiting to the `booksCtrl.getAllBooks` route handler. We can use the `express-rate-limit` package, which is already imported in the code. We will create a rate limiter specifically for the `getAllBooks` route and apply it to the route handler.

1. Define a new rate limiter for the `getAllBooks` route.
2. Apply the rate limiter to the `getAllBooks` route handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
