### PR TITLE
Potential fix for code scanning alert no. 1: Database query built from user-controlled sources

### DIFF
--- a/controllers/books.js
+++ b/controllers/books.js
@@ -56,7 +56,14 @@ exports.modifyBook = (req, res, next) => {
                 req.file && fs.unlink(`images/${filename}`, (err => {
                     if (err) console.log(err);
                 }));
-                Book.updateOne({ _id: req.params.id}, { ...bookObject, _id: req.params.id})
+                const updateFields = {
+                    title: bookObject.title,
+                    author: bookObject.author,
+                    description: bookObject.description,
+                    imageUrl: bookObject.imageUrl,
+                    averageRating: bookObject.averageRating
+                };
+                Book.updateOne({ _id: req.params.id}, { $set: updateFields })
                 .then(() => res.status(200).json({message : 'Livre modifié!'}))
                 .catch(error => res.status(401).json({ error }));
             }


### PR DESCRIPTION
Potential fix for [https://github.com/Bernard-VERA/Projet-7/security/code-scanning/1](https://github.com/Bernard-VERA/Projet-7/security/code-scanning/1)

To fix the problem, we need to ensure that the user-provided data is properly sanitized and validated before being used in the MongoDB query. One effective way to achieve this is by using the `$set` operator in the `updateOne` query to explicitly specify the fields that can be updated. This approach prevents the user from injecting malicious query objects.

We will:
1. Validate the `bookObject` to ensure it only contains the allowed fields.
2. Use the `$set` operator in the `updateOne` query to update only the specified fields.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
