### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled data used in path expression

### DIFF
--- a/middleware/multer.js
+++ b/middleware/multer.js
@@ -34,8 +34,10 @@ module.exports.resizeImage = (req, res, next) => {
  
   const newFilePath = path.join('images', `resized_${fileName}`);
 
-  // Ensure the filePath is within the 'images' directory
-  if (!filePath.startsWith(path.resolve('images'))) {
+  // Normalize and validate the filePath
+  const resolvedFilePath = fs.realpathSync(filePath);
+  const rootDir = path.resolve('images');
+  if (!resolvedFilePath.startsWith(rootDir)) {
     console.log('Invalid file path');
     return next();
   }


### PR DESCRIPTION
Potential fix for [https://github.com/Bernard-VERA/Projet-7/security/code-scanning/12](https://github.com/Bernard-VERA/Projet-7/security/code-scanning/12)

To fix the problem, we need to ensure that the `filePath` is strictly within the 'images' directory. This can be achieved by normalizing the path using `path.resolve` and then checking if the normalized path starts with the root 'images' directory. Additionally, we should use `fs.realpathSync` to resolve the actual path on the filesystem, which helps in handling symbolic links and other filesystem quirks.

1. Normalize the `filePath` using `path.resolve`.
2. Use `fs.realpathSync` to get the actual path on the filesystem.
3. Check if the resolved path starts with the root 'images' directory.
4. If the path is valid, proceed with the image resizing and deletion. Otherwise, log an error and call `next()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
