### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/routes/books.js
+++ b/routes/books.js
@@ -15,9 +15,14 @@ const getAllBooksLimiter = rateLimit({
 router.get('/', getAllBooksLimiter, booksCtrl.getAllBooks);
 router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
-router.post('/', auth, multer, multer.resizeImage, booksCtrl.createBook);
-router.post('/:id/rating', auth, booksCtrl.createRating);
-router.put('/:id', auth, multer, multer.resizeImage, booksCtrl.modifyBook);
+router.post('/', authLimiter, auth, multer, multer.resizeImage, booksCtrl.createBook);
+router.post('/:id/rating', authLimiter, auth, booksCtrl.createRating);
+router.put('/:id', authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
+const authLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 50 // limit each IP to 50 requests per windowMs for authenticated routes
+});
+
 const deleteBookLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 10 // limit each IP to 10 delete requests per windowMs

--- a/routes/books.js
+++ b/routes/books.js
@@ -15,7 +15,7 @@ const getAllBooksLimiter = rateLimit({
 router.get('/', getAllBooksLimiter, booksCtrl.getAllBooks);
 router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
-router.post('/', authLimiter, auth, multer, multer.resizeImage, booksCtrl.createBook);
+router.post('/', createBookLimiter, auth, multer, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', authLimiter, auth, booksCtrl.createRating);
 router.put('/:id', authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
 const authLimiter = rateLimit({
@@ -26,6 +26,11 @@ const authLimiter = rateLimit({
 const deleteBookLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 10 // limit each IP to 10 delete requests per windowMs
+});
+
+const createBookLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 20 // limit each IP to 20 create book requests per windowMs
 });
 
 router.delete('/:id', auth, deleteBookLimiter, booksCtrl.deleteBook);


### PR DESCRIPTION
Potential fix for [https://github.com/Bernard-VERA/Projet-7/security/code-scanning/5](https://github.com/Bernard-VERA/Projet-7/security/code-scanning/5)

To fix the problem, we need to add rate limiting to the routes that perform expensive operations, specifically the routes that use the `auth` middleware. We will use the `express-rate-limit` package to implement rate limiting. We will define a rate limiter for these routes and apply it to the relevant routes.

1. Define a rate limiter for the routes that use the `auth` middleware.
2. Apply the rate limiter to the routes that perform expensive operations, such as creating a book, modifying a book, and creating a rating.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
