### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled data used in path expression

### DIFF
--- a/middleware/multer.js
+++ b/middleware/multer.js
@@ -38,7 +38,13 @@ module.exports.resizeImage = (req, res, next) => {
   }
   const fileName = req.file.filename;
  
-  const newFilePath = path.join('images', `resized_${fileName}`);
+  let newFilePath;
+  try {
+    newFilePath = path.resolve('images', `resized_${fileName}`);
+  } catch (err) {
+    console.log('Error resolving new file path:', err);
+    return next();
+  }
 
   // Normalize and validate the filePath
   let resolvedFilePath;
@@ -51,6 +57,19 @@ module.exports.resizeImage = (req, res, next) => {
   const rootDir = path.resolve('images');
   if (!resolvedFilePath.startsWith(rootDir)) {
     console.log('Invalid file path');
+    return next();
+  }
+
+  // Validate the newFilePath
+  let resolvedNewFilePath;
+  try {
+    resolvedNewFilePath = fs.realpathSync(newFilePath);
+  } catch (err) {
+    console.log('Error resolving real new file path:', err);
+    return next();
+  }
+  if (!resolvedNewFilePath.startsWith(rootDir)) {
+    console.log('Invalid new file path');
     return next();
   }
 

--- a/middleware/multer.js
+++ b/middleware/multer.js
@@ -29,13 +29,25 @@ module.exports.resizeImage = (req, res, next) => {
     return next();
   }
 
-  const filePath = path.resolve(req.file.path);
+  let filePath;
+  try {
+    filePath = path.resolve(req.file.path);
+  } catch (err) {
+    console.log('Error resolving file path:', err);
+    return next();
+  }
   const fileName = req.file.filename;
  
   const newFilePath = path.join('images', `resized_${fileName}`);
 
   // Normalize and validate the filePath
-  const resolvedFilePath = fs.realpathSync(filePath);
+  let resolvedFilePath;
+  try {
+    resolvedFilePath = fs.realpathSync(filePath);
+  } catch (err) {
+    console.log('Error resolving real file path:', err);
+    return next();
+  }
   const rootDir = path.resolve('images');
   if (!resolvedFilePath.startsWith(rootDir)) {
     console.log('Invalid file path');


### PR DESCRIPTION
Potential fix for [https://github.com/Bernard-VERA/Projet-7/security/code-scanning/12](https://github.com/Bernard-VERA/Projet-7/security/code-scanning/12)

To fix the problem, we need to ensure that the `filePath` is properly validated and handled. We should:
1. Use `path.resolve` to normalize the `filePath`.
2. Use `fs.realpathSync` to get the absolute path and ensure it is within the `images` directory.
3. Handle any potential errors that might occur during the path resolution process.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
