### PR TITLE
Potential fix for code scanning alert no. 27: Missing rate limiting

### DIFF
--- a/routes/books.js
+++ b/routes/books.js
@@ -28,7 +28,7 @@ const deleteBookLimiter = rateLimit({
     max: 10 // limit each IP to 10 delete requests per windowMs
 });
 
-router.delete('/:id', auth, deleteBookLimiter, booksCtrl.deleteBook);
+router.delete('/:id', deleteBookLimiter, auth, booksCtrl.deleteBook);
 
 const createBookLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes


### PR DESCRIPTION
Potential fix for [https://github.com/Bernard-VERA/Projet-7/security/code-scanning/27](https://github.com/Bernard-VERA/Projet-7/security/code-scanning/27)

To fix the problem, we need to ensure that the `deleteBookLimiter` rate limiting middleware is applied before the `auth` middleware on the route that handles deleting a book. This will ensure that the rate limiting is enforced before any authorization logic is executed, protecting the route from potential denial-of-service attacks.

We will move the `deleteBookLimiter` middleware to be the first middleware in the route definition for deleting a book. This change will be made in the `routes/books.js` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
