### PR TITLE
Potential fix for code scanning alert no. 21: Missing rate limiting

### DIFF
--- a/routes/books.js
+++ b/routes/books.js
@@ -16,7 +16,7 @@ router.get('/', getAllBooksLimiter, booksCtrl.getAllBooks);
 router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, auth, multer, multer.resizeImage, booksCtrl.createBook);
-router.post('/:id/rating', createRatingLimiter, auth, booksCtrl.createRating);
+router.post('/:id/rating', createRatingLimiter, authLimiter, auth, booksCtrl.createRating);
 router.put('/:id', authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
 const authLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes

--- a/routes/books.js
+++ b/routes/books.js
@@ -16,7 +16,7 @@ router.get('/', getAllBooksLimiter, booksCtrl.getAllBooks);
 router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, auth, multer, multer.resizeImage, booksCtrl.createBook);
-router.post('/:id/rating', authLimiter, auth, booksCtrl.createRating);
+router.post('/:id/rating', createRatingLimiter, auth, booksCtrl.createRating);
 router.put('/:id', authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
 const authLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
@@ -29,6 +29,11 @@ const deleteBookLimiter = rateLimit({
 });
 
 router.delete('/:id', deleteBookLimiter, auth, booksCtrl.deleteBook);
+
+const createRatingLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 30 // limit each IP to 30 create rating requests per windowMs
+});
 
 const createBookLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes


### PR DESCRIPTION
Potential fix for [https://github.com/Bernard-VERA/Projet-7/security/code-scanning/21](https://github.com/Bernard-VERA/Projet-7/security/code-scanning/21)

To fix the problem, we need to add rate limiting to the `booksCtrl.createRating` route. This can be achieved by defining a rate limiter specifically for this route and applying it to the route handler. We will use the `express-rate-limit` package, which is already imported in the code.

1. Define a rate limiter for the `booksCtrl.createRating` route.
2. Apply the rate limiter to the `booksCtrl.createRating` route handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
