### PR TITLE
Potential fix for code scanning alert no. 22: Missing rate limiting

### DIFF
--- a/routes/books.js
+++ b/routes/books.js
@@ -17,7 +17,7 @@ router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, auth, multer, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, auth, booksCtrl.createRating);
-router.put('/:id', authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
+router.put('/:id', modifyBookLimiter, authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
 const authLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 50 // limit each IP to 50 requests per windowMs for authenticated routes
@@ -38,6 +38,11 @@ const createRatingLimiter = rateLimit({
 const createBookLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 20 // limit each IP to 20 create book requests per windowMs
+});
+
+const modifyBookLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 20 // limit each IP to 20 modify book requests per windowMs
 });
 
 module.exports = router;

--- a/routes/books.js
+++ b/routes/books.js
@@ -18,6 +18,7 @@ router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, auth, multer, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, auth, booksCtrl.createRating);
 router.put('/:id', modifyBookLimiter, authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
+
 const authLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 50 // limit each IP to 50 requests per windowMs for authenticated routes


### PR DESCRIPTION
Potential fix for [https://github.com/Bernard-VERA/Projet-7/security/code-scanning/22](https://github.com/Bernard-VERA/Projet-7/security/code-scanning/22)

To fix the problem, we need to add a rate limiter to the route that uses the `auth` middleware. This will ensure that the route is protected against denial-of-service attacks by limiting the number of requests that can be made in a given time window.

The best way to fix the problem without changing existing functionality is to define a new rate limiter specifically for the route in question and apply it to the route. We will add the rate limiter to the route that modifies a book (`router.put('/:id', ...)`).

We will define a new rate limiter called `modifyBookLimiter` and apply it to the route. This rate limiter will limit each IP to 20 requests per 15 minutes, similar to the other rate limiters in the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
