### PR TITLE
Potential fix for code scanning alert no. 30: Missing rate limiting

### DIFF
--- a/routes/books.js
+++ b/routes/books.js
@@ -18,6 +18,7 @@ router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, auth, booksCtrl.createRating);
 router.put('/:id', modifyBookLimiter, authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
+router.post('/', createBookLimiter, authLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 
 const authLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes

--- a/routes/books.js
+++ b/routes/books.js
@@ -18,7 +18,7 @@ router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, auth, booksCtrl.createRating);
 router.put('/:id', modifyBookLimiter, authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
-router.post('/', createBookLimiter, authLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
+router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 
 const authLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
@@ -45,6 +45,11 @@ const createBookLimiter = rateLimit({
 const resizeImageLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 20 // limit each IP to 20 resize image requests per windowMs
+});
+
+const authRateLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 50 // limit each IP to 50 auth requests per windowMs
 });
 
 const modifyBookLimiter = rateLimit({

--- a/routes/books.js
+++ b/routes/books.js
@@ -18,7 +18,7 @@ router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, auth, booksCtrl.createRating);
 router.put('/:id', modifyBookLimiter, authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
-router.post('/', createBookLimiter, authLimiter, authRateLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
+router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 
 const authLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes

--- a/routes/books.js
+++ b/routes/books.js
@@ -15,7 +15,7 @@ const getAllBooksLimiter = rateLimit({
 router.get('/', getAllBooksLimiter, booksCtrl.getAllBooks);
 router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
-router.post('/', createBookLimiter, authLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
+router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, auth, booksCtrl.createRating);
 router.put('/:id', modifyBookLimiter, authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);

--- a/routes/books.js
+++ b/routes/books.js
@@ -18,7 +18,7 @@ router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, auth, booksCtrl.createRating);
 router.put('/:id', modifyBookLimiter, authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
-router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
+router.post('/', createBookLimiter, authLimiter, authRateLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 
 const authLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes


### PR DESCRIPTION
Potential fix for [https://github.com/Bernard-VERA/Projet-7/security/code-scanning/30](https://github.com/Bernard-VERA/Projet-7/security/code-scanning/30)

To fix the problem, we need to add rate limiting to the routes that use the `auth` middleware. This can be done by creating a rate limiter specifically for authenticated routes and applying it to the relevant routes. We will use the `express-rate-limit` package to create a rate limiter that limits each IP to a certain number of requests per window of time (e.g., 15 minutes).

We will add the `authLimiter` to the routes that use the `auth` middleware, ensuring that these routes are protected against denial-of-service attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
