### PR TITLE
Potential fix for code scanning alert no. 30: Missing rate limiting

### DIFF
--- a/routes/books.js
+++ b/routes/books.js
@@ -16,7 +16,7 @@ router.get('/', getAllBooksLimiter, booksCtrl.getAllBooks);
 router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
-router.post('/:id/rating', createRatingLimiter, authLimiter, authRateLimiter, auth, booksCtrl.createRating);
+router.post('/:id/rating', createRatingLimiter, authLimiter, authRateLimiter, authRateLimiter, auth, booksCtrl.createRating);
 router.put('/:id', modifyBookLimiter, authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 

--- a/routes/books.js
+++ b/routes/books.js
@@ -16,7 +16,7 @@ router.get('/', getAllBooksLimiter, booksCtrl.getAllBooks);
 router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
-router.post('/:id/rating', createRatingLimiter, authLimiter, auth, booksCtrl.createRating);
+router.post('/:id/rating', createRatingLimiter, authLimiter, authRateLimiter, auth, booksCtrl.createRating);
 router.put('/:id', modifyBookLimiter, authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 

--- a/routes/books.js
+++ b/routes/books.js
@@ -16,7 +16,7 @@ router.get('/', getAllBooksLimiter, booksCtrl.getAllBooks);
 router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
-router.post('/:id/rating', createRatingLimiter, authLimiter, authRateLimiter, authRateLimiter, auth, booksCtrl.createRating);
+router.post('/:id/rating', createRatingLimiter, authLimiter, authRateLimiter, auth, booksCtrl.createRating);
 router.put('/:id', modifyBookLimiter, authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Bernard-VERA/Projet-7/security/code-scanning/30](https://github.com/Bernard-VERA/Projet-7/security/code-scanning/30)

To fix the problem, we need to ensure that the `auth` middleware is rate-limited. We can achieve this by applying an appropriate rate limiter to the route that uses the `auth` middleware. Specifically, we should add the `authRateLimiter` to the route on line 19 where the `auth` middleware is used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
