### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled data used in path expression

### DIFF
--- a/middleware/multer.js
+++ b/middleware/multer.js
@@ -29,6 +29,8 @@ module.exports.resizeImage = (req, res, next) => {
     return next();
   }
 
+  const rootDir = path.resolve('images');
+
   let filePath;
   try {
     filePath = path.resolve(req.file.path);
@@ -54,7 +56,6 @@ module.exports.resizeImage = (req, res, next) => {
     console.log('Error resolving real file path:', err);
     return next();
   }
-  const rootDir = path.resolve('images');
   if (!resolvedFilePath.startsWith(rootDir)) {
     console.log('Invalid file path');
     return next();
@@ -74,12 +75,12 @@ module.exports.resizeImage = (req, res, next) => {
   }
 
   sharp.cache(false)
-  sharp(filePath)
+  sharp(resolvedFilePath)
     .resize({ width: 206, fit: sharp.fit.contain })
-    .toFile(newFilePath)
+    .toFile(resolvedNewFilePath)
     .then(() => {
-      fs.unlink(filePath, (error) => {
-        req.file.path = newFilePath;
+      fs.unlink(resolvedFilePath, (error) => {
+        req.file.path = resolvedNewFilePath;
         next();
       });
     })

--- a/middleware/multer.js
+++ b/middleware/multer.js
@@ -33,7 +33,7 @@ module.exports.resizeImage = (req, res, next) => {
 
   let filePath;
   try {
-    filePath = path.resolve(req.file.path);
+    filePath = path.resolve(rootDir, req.file.path);
   } catch (err) {
     console.log('Error resolving file path:', err);
     return next();
@@ -42,7 +42,7 @@ module.exports.resizeImage = (req, res, next) => {
  
   let newFilePath;
   try {
-    newFilePath = path.resolve('images', `resized_${fileName}`);
+    newFilePath = path.resolve(rootDir, `resized_${fileName}`);
   } catch (err) {
     console.log('Error resolving new file path:', err);
     return next();


### PR DESCRIPTION
Potential fix for [https://github.com/Bernard-VERA/Projet-7/security/code-scanning/12](https://github.com/Bernard-VERA/Projet-7/security/code-scanning/12)

To fix the problem, we need to ensure that the `filePath` is securely validated before performing any file operations. This involves normalizing the path using `path.resolve` and `fs.realpathSync` to remove any ".." segments and then checking that the normalized path starts with the root directory. Additionally, we should ensure that the `newFilePath` is also validated in the same manner.

1. Normalize the `filePath` using `path.resolve` and `fs.realpathSync`.
2. Check that the normalized `filePath` starts with the root directory.
3. Normalize the `newFilePath` using `path.resolve` and `fs.realpathSync`.
4. Check that the normalized `newFilePath` starts with the root directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
