### PR TITLE
Potential fix for code scanning alert no. 32: Missing rate limiting

### DIFF
--- a/routes/books.js
+++ b/routes/books.js
@@ -17,7 +17,7 @@ router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, authRateLimiter, auth, booksCtrl.createRating);
-router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, resizeImageLimiter, booksCtrl.modifyBook);
+router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.modifyBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 
 const authLimiter = rateLimit({

--- a/routes/books.js
+++ b/routes/books.js
@@ -17,7 +17,7 @@ router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, authRateLimiter, auth, booksCtrl.createRating);
-router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, authLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.modifyBook);
+router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, authLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, resizeImageLimiter, booksCtrl.modifyBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 
 const authLimiter = rateLimit({

--- a/routes/books.js
+++ b/routes/books.js
@@ -17,7 +17,7 @@ router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, authRateLimiter, auth, booksCtrl.createRating);
-router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
+router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 
 const authLimiter = rateLimit({

--- a/routes/books.js
+++ b/routes/books.js
@@ -17,7 +17,7 @@ router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, authRateLimiter, auth, booksCtrl.createRating);
-router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, authLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, resizeImageLimiter, booksCtrl.modifyBook);
+router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, resizeImageLimiter, booksCtrl.modifyBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 
 const authLimiter = rateLimit({

--- a/routes/books.js
+++ b/routes/books.js
@@ -17,7 +17,7 @@ router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, authRateLimiter, auth, booksCtrl.createRating);
-router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
+router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 
 const authLimiter = rateLimit({

--- a/routes/books.js
+++ b/routes/books.js
@@ -17,7 +17,7 @@ router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, authRateLimiter, auth, booksCtrl.createRating);
-router.put('/:id', modifyBookLimiter, authLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
+router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 
 const authLimiter = rateLimit({

--- a/routes/books.js
+++ b/routes/books.js
@@ -17,7 +17,7 @@ router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, authRateLimiter, auth, booksCtrl.createRating);
-router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.modifyBook);
+router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, authLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.modifyBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 
 const authLimiter = rateLimit({

--- a/routes/books.js
+++ b/routes/books.js
@@ -17,7 +17,7 @@ router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, authRateLimiter, auth, booksCtrl.createRating);
-router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, auth, multer, multer.resizeImage, booksCtrl.modifyBook);
+router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.modifyBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 
 const authLimiter = rateLimit({

--- a/routes/books.js
+++ b/routes/books.js
@@ -17,7 +17,7 @@ router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, authRateLimiter, auth, booksCtrl.createRating);
-router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, resizeImageLimiter, booksCtrl.modifyBook);
+router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, resizeImageLimiter, booksCtrl.modifyBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 
 const authLimiter = rateLimit({


### PR DESCRIPTION
Potential fix for [https://github.com/Bernard-VERA/Projet-7/security/code-scanning/32](https://github.com/Bernard-VERA/Projet-7/security/code-scanning/32)

To fix the problem, we need to apply a rate limiter to the route that uses the `auth` middleware. This can be done by creating a rate limiter specifically for the `auth` middleware and applying it to the route. We will use the `express-rate-limit` package, which is already imported in the file.

- Create a new rate limiter for the `auth` middleware.
- Apply this rate limiter to the route that uses the `auth` middleware.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
