### PR TITLE
Potential fix for code scanning alert no. 41: Missing rate limiting

### DIFF
--- a/routes/books.js
+++ b/routes/books.js
@@ -15,7 +15,7 @@ const getAllBooksLimiter = rateLimit({
 router.get('/', getAllBooksLimiter, booksCtrl.getAllBooks);
 router.get('/bestrating', booksCtrl.getBestRating);
 router.get('/:id', booksCtrl.getOneBook);
-router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
+router.post('/', createBookLimiter, authLimiter, authRateLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);
 router.post('/:id/rating', createRatingLimiter, authLimiter, authRateLimiter, auth, booksCtrl.createRating);
 router.put('/:id', modifyBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.modifyBook);
 router.post('/', createBookLimiter, authLimiter, authRateLimiter, auth, multer, resizeImageLimiter, multer.resizeImage, booksCtrl.createBook);


### PR DESCRIPTION
Potential fix for [https://github.com/Bernard-VERA/Projet-7/security/code-scanning/41](https://github.com/Bernard-VERA/Projet-7/security/code-scanning/41)

To fix the problem, we need to ensure that the `auth` middleware is rate-limited. We can achieve this by applying the existing `authRateLimiter` to the route that uses the `auth` middleware. This will limit the number of requests that can be made to the authorization endpoint, preventing potential denial-of-service attacks.

We will add the `authRateLimiter` to the route on line 18 where the `auth` middleware is used. This will involve modifying the route definition to include the `authRateLimiter` before the `auth` middleware.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
